### PR TITLE
:sparkles: Add/Remove User From Group Chat

### DIFF
--- a/lib/flutter_chatview_db_connection.dart
+++ b/lib/flutter_chatview_db_connection.dart
@@ -16,6 +16,8 @@ export 'src/enum.dart'
     hide
         ChatRoomTypeExtension,
         DocumentChangeTypeExtension,
+        MembershipStatusExtension,
+        RoleExtension,
         TypeWriterStatusExtension,
         UserStatusExtension;
 export 'src/models/models.dart';

--- a/lib/src/enum.dart
+++ b/lib/src/enum.dart
@@ -212,3 +212,84 @@ extension ChatRoomTypeExtension on ChatRoomType {
     }
   }
 }
+
+/// Represents the different roles a user can have in the chat system.
+enum Role {
+  /// An admin has the highest level of control.
+  /// They can manage users, delete messages, and moderate chatrooms.
+  admin,
+
+  /// A regular user who can participate in chat.
+  /// They can send and receive messages but have no moderation privileges.
+  user;
+
+  /// Returns `true` if the user is an admin.
+  bool get isAdmin => this == admin;
+
+  /// Returns `true` if the user is a regular chat participant.
+  bool get isUser => this == user;
+}
+
+/// Provides utility methods for [RoleExtension].
+extension RoleExtension on Role {
+  /// Parses a string value and returns the corresponding [Role].
+  ///
+  /// **Parameters:**
+  /// (required): [value] The input string to parse.
+  ///
+  /// Returns the corresponding [Role] if the value matches.
+  /// Defaults to [Role.admin] if the input is empty or doesn't match any role.
+  static Role parse(String? value) {
+    final type = value?.trim().toLowerCase() ?? '';
+    if (type.isEmpty) return Role.admin;
+    if (type == Role.admin.name.toLowerCase()) {
+      return Role.admin;
+    } else {
+      return Role.user;
+    }
+  }
+}
+
+/// Represents the membership status of a user in a chat group.
+enum MembershipStatus {
+  /// The user is an active member of the group.
+  member,
+
+  /// The user has been removed from the group.
+  removed,
+
+  /// The user voluntarily left the group.
+  left;
+
+  /// Returns `true` if the user is an active member of the group.
+  bool get isMember => this == member;
+
+  /// Returns `true` if the user has been removed from the group.
+  bool get isRemoved => this == removed;
+
+  /// Returns `true` if the user has voluntarily left the group.
+  bool get isLeft => this == left;
+}
+
+/// Provides utility methods for [MembershipStatusExtension].
+extension MembershipStatusExtension on MembershipStatus {
+  /// Parses a string value and returns the corresponding [MembershipStatus].
+  ///
+  /// **Parameters:**
+  /// (required): [value] The input string to parse.
+  ///
+  /// Returns the corresponding [MembershipStatus] if the value matches.
+  /// Defaults to [MembershipStatus.member] if the input is empty or doesn't
+  /// match any status.
+  static MembershipStatus parse(String? value) {
+    final type = value?.trim().toLowerCase() ?? '';
+    if (type.isEmpty) return MembershipStatus.member;
+    if (type == MembershipStatus.removed.name.toLowerCase()) {
+      return MembershipStatus.removed;
+    } else if (type == MembershipStatus.left.name.toLowerCase()) {
+      return MembershipStatus.left;
+    } else {
+      return MembershipStatus.member;
+    }
+  }
+}

--- a/lib/src/models/chat_room_user_dm.dart
+++ b/lib/src/models/chat_room_user_dm.dart
@@ -8,16 +8,25 @@ class ChatRoomUserDm {
   /// Constructs a [ChatRoomUserDm] instance.
   ///
   /// **Parameters:**
-  /// - (optional): [userId] is the unique identifier of the user.
-  /// - (optional): [chatUser] contains detailed information about the user
+  /// - (required): [userId] is the unique identifier of the user.
+  /// - (required): [chatUser] contains detailed information about the user
   /// in the chat room.
-  /// - (optional): [userStatus] represents the online/offline status of the user.
+  /// - (required): [userStatus] represents the online/offline status of the user.
   /// - (optional): [typingStatus] indicates the typing status of the user,
   /// with a default value of [TypeWriterStatus.typed].
+  /// - (required): [role] defines the user's permissions within the chat room.
+  /// - (required): [membershipStatus] indicates whether the user is an active
+  /// member, has left, or was removed.
+  /// - (required): [membershipStatusTimestamp] records the timestamp of
+  /// the last membership status change, helping track when a user joined,
+  /// left, or was removed.
   const ChatRoomUserDm({
+    required this.role,
     required this.userId,
     required this.chatUser,
     required this.userStatus,
+    required this.membershipStatus,
+    required this.membershipStatusTimestamp,
     this.typingStatus = TypeWriterStatus.typed,
   });
 
@@ -42,6 +51,13 @@ class ChatRoomUserDm {
       typingStatus: TypeWriterStatusExtension.parse(
         json['typing_status'].toString(),
       ),
+      role: RoleExtension.parse(json['role'].toString()),
+      membershipStatus: MembershipStatusExtension.parse(
+        json['membership_status'].toString(),
+      ),
+      membershipStatusTimestamp: DateTime.tryParse(
+        json['membership_status_timestamp'].toString(),
+      ),
     );
   }
 
@@ -63,6 +79,22 @@ class ChatRoomUserDm {
   /// Possible values include statuses such as typing or typed.
   final TypeWriterStatus typingStatus;
 
+  /// The role of the user in the chat room.
+  ///
+  /// Determines the user's permissions within the chat.
+  final Role role;
+
+  /// The membership status of the user in the chat room.
+  ///
+  /// Indicates whether the user is an active member, has left, or was removed.
+  final MembershipStatus membershipStatus;
+
+  /// The timestamp of the last membership status change.
+  /// This helps determine when a user joined, left, or was removed from
+  /// the chat room.
+  /// If `null`, the exact time of the status change is unknown.
+  final DateTime? membershipStatusTimestamp;
+
   /// Converts the [ChatRoomUserDm] instance to a JSON map.
   ///
   /// **Note**: The [chatUser] field is not included in `toJson`
@@ -81,8 +113,12 @@ class ChatRoomUserDm {
   Map<String, dynamic> toJson({bool includeUserId = true}) {
     return {
       if (includeUserId) 'user_id': userId,
+      'role': role.name,
       'user_status': userStatus.name,
       'typing_status': typingStatus.name,
+      'membership_status': membershipStatus.name,
+      'membership_status_timestamp':
+          membershipStatusTimestamp?.toIso8601String(),
     };
   }
 
@@ -92,24 +128,37 @@ class ChatRoomUserDm {
   /// Any field not provided will retain its current value.
   ///
   /// **Parameters:**
+  /// - (optional): [role] is the updated role of the user in the chat room.
   /// - (optional): [userId] is the updated user ID.
   /// - (optional): [chatUser] is the updated chat user details.
   /// - (optional): [userStatus] is the updated online/offline status.
   /// - (optional): [typingStatus] is the updated typing status.
+  /// - (optional): [membershipStatus] is the updated membership status
+  /// of the user in the chat room.
+  /// - (optional): [membershipStatusTimestamp] is the updated timestamp
+  /// of the last membership status change. If `null`, the existing
+  /// timestamp is retained.
   ///
   /// Returns a new [ChatRoomUserDm] instance with the specified updates.
   ChatRoomUserDm copyWith({
+    Role? role,
     String? userId,
     ChatUser? chatUser,
     UserStatus? userStatus,
     TypeWriterStatus? typingStatus,
+    MembershipStatus? membershipStatus,
+    DateTime? membershipStatusTimestamp,
     bool forceNullValue = false,
   }) {
     return ChatRoomUserDm(
+      role: role ?? this.role,
       userId: userId ?? this.userId,
       chatUser: forceNullValue ? chatUser : chatUser ?? this.chatUser,
       userStatus: userStatus ?? this.userStatus,
       typingStatus: typingStatus ?? this.typingStatus,
+      membershipStatus: membershipStatus ?? this.membershipStatus,
+      membershipStatusTimestamp:
+          membershipStatusTimestamp ?? this.membershipStatusTimestamp,
     );
   }
 

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -66,3 +66,16 @@ typedef ChatRoomInitializedCallback = void Function(
 /// };
 /// ```
 typedef ChatMessagesChangeCallback = void Function(List<MessageDm> messages);
+
+/// Represents a record of chat room participants,
+/// including the current user and other users in the chat.
+///
+/// **Fields:**
+/// - (optional) `currentUser` The current user participating in the chat room.
+/// If `null`, the user may not be a member.
+/// - (required) `otherUsers` A list of other users in the chat room excluding
+/// the current user.
+typedef ChatRoomParticipantsRecord = ({
+  ChatRoomUserDm? currentUser,
+  List<ChatRoomUserDm> otherUsers,
+});


### PR DESCRIPTION
- Updated `getChats` stream with handling messages count based on group joined
- Added add user remove user from group methods
- Added `starFromDateTime` param in `getUnreadMessagesCount` and `getMessagesStream` methods
- Added `membershipStatusTimestamp` to track user status
- Added other param in `updateChatRoomUser` method
- Added method to get active membership timestamp from group chat
- Added `forceNullValue` in chat room copy with method